### PR TITLE
Fix VoiceState type, endpoint can be string or null

### DIFF
--- a/v4/Player.d.ts
+++ b/v4/Player.d.ts
@@ -139,6 +139,6 @@ export type LowPass = {
 
 export type VoiceState = {
 	token: string;
-	endpoint?: string;
+	endpoint: string | null;
 	sessionId: string;
 }

--- a/v4/Player.d.ts
+++ b/v4/Player.d.ts
@@ -139,6 +139,6 @@ export type LowPass = {
 
 export type VoiceState = {
 	token: string;
-	endpoint: string;
+	endpoint?: string;
 	sessionId: string;
 }


### PR DESCRIPTION
added optional operator to endpoint property  in VoiceState according to discord api documentation

https://discord.com/developers/docs/events/gateway-events#voice-server-update